### PR TITLE
VIVI-6018 Generate fake dash manifest for segmented videos

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,9 +6,67 @@ const EN_LIST = ['en-US', 'en-GB', 'en', 'en-AU'];
 
 // public
 
-module.exports.ARGUMENTS = ['--restrict-filenames', '--write-sub', '--write-auto-sub', '--no-playlist', '-f', '[height <=? 720][format_id != source]', '-j'];
+const commonProperties = [
+  '[format_id!=source]',
+  '[vcodec!*=av01]',
+  '[vcodec!*=vp9]'
+].join('');
+
+const formatPreferences = [
+  'best[height = 1080][fps <= 30]',
+  'best[height <=? 720]'
+].join('/');
+
+module.exports.ARGUMENTS = [
+  '--restrict-filenames',
+  '--write-sub',
+  '--write-auto-sub',
+  '--no-playlist',
+  '-f', `(${formatPreferences})${commonProperties}`,
+  '-j'
+];
 
 module.exports.PLAYLIST_ARGUMENTS = ['--flat-playlist', '-j'];
+
+const timescale = 48000;
+
+const generateManifestDataUrl = (data) => {
+  const { duration, ext, format_id, fragments, fragment_base_url } = data;
+  const durationString = `PT${Math.floor(duration / 60)}M${duration % 60}S`
+  let time = 0;
+
+  const manifestString = `<?xml version="1.0" encoding="UTF-8"?>
+    <MPD
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns="urn:mpeg:dash:schema:mpd:2011"
+      profiles="urn:mpeg:dash:profile:isoff-live:2011"
+      mediaPresentationDuration="${durationString}"
+      type="static"
+    >
+      <BaseURL><![CDATA[${fragment_base_url || ''}]]></BaseURL>
+      <Period start="PT0.000S" duration="${durationString}">
+        <AdaptationSet mimeType="video/${ext}">
+          <Representation id="${format_id}" bandwidth="4382360">
+            <SegmentList timescale="${timescale}">
+              ${fragments.map((fragment) => `<SegmentURL media="${fragment.path}" />`)}
+              <SegmentTimeline> 
+                ${fragments.map((fragment) => {
+                  const duration = (fragment.duration || 0.01) * timescale;
+                  const segment = `<S t="${time}" d="${duration}"></S>`;
+                  time += duration;
+                  return segment;
+                })}
+              </SegmentTimeline>
+            </SegmentList>
+          </Representation>
+        </AdaptationSet>
+      </Period>
+    </MPD>`;
+
+  return (
+    `data:application/dash+xml;base64,${Buffer.from(manifestString).toString('base64')}`
+  )
+};
 
 module.exports.isPlaylist = (url) => {
   return url.startsWith('https://www.youtube.com/playlist?list=');
@@ -16,21 +74,35 @@ module.exports.isPlaylist = (url) => {
 
 module.exports.process = (output, origin) => {
   const data = JSON.parse(output.toString().trim());
-  const { url } = data;
-  if (!url) {
-    throw 'no url';
+  const { automatic_captions, subtitles, url } = data;
+
+  const cookies = data.http_headers && data.http_headers.Cookie || '';
+  const duration = data.duration || 0;
+  const subtitleFile = findBestSubtitleFile(subtitles) || findBestSubtitleFile(automatic_captions);
+  const subtitleUrl = subtitleFile ? `${origin}/ytdl/vtt?suburi=${encodeURIComponent(subtitleFile.subs.url)}` : '';
+  const title = data.title || '';
+
+  if (data.fragments) {
+    return {
+      cookies,
+      duration,
+      subtitle_url: subtitleUrl,
+      title,
+      url: generateManifestDataUrl(data),
+    };
   }
 
-  const subtitleFile = findBestSubtitleFile(data.subtitles) || findBestSubtitleFile(data.automatic_captions);
-  const subtitleUrl = subtitleFile ? `${origin}/ytdl/vtt?suburi=${encodeURIComponent(subtitleFile.subs.url)}` : '';
+  if (url) {
+    return {
+      cookies,
+      duration,
+      subtitle_url: subtitleUrl,
+      title,
+      url
+    };
+  }
 
-  return {
-    title: data.title || '',
-    url,
-    duration: data.duration || 0,
-    subtitle_url: subtitleUrl,
-    cookies: data.http_headers.Cookie || ''
-  };
+  throw 'no url';
 };
 
 module.exports.processPlaylist = (output) => {

--- a/service.py
+++ b/service.py
@@ -43,7 +43,7 @@ class Handler(BaseHTTPRequestHandler):
             'simulate': True
         }
         if url.path == '/process':
-            ydl_opts['format'] = '[height <=? 720][format_id != source]'
+            ydl_opts['format'] = '(best[height = 1080][fps <= 30]/best[height <=? 720])[format_id!=source][vcodec!*=av01][vcodec!*=vp9]'
             ydl_opts['noplaylist'] = True
             ydl_opts['restrictfilenames'] = True
             ydl_opts['writeautomaticsub'] = True


### PR DESCRIPTION
- This prevents videos with quality above the limits specified to be used when the server returns a DASH manifest
- Draft for now, since I'm not sure this is required for android, we may be able to return the unmodified manifest