### PR TITLE
VIVI-6690 Fix invalid timestamps

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,14 +62,14 @@ const generateManifest = (data) => {
         <AdaptationSet mimeType="video/${ext}">
           <Representation id="${format_id}" bandwidth="4382360">
             <SegmentList timescale="${timescale}">
-              ${fragments.map((fragment) => `<SegmentURL media="${fragment.path}" />`)}
+              ${fragments.map((fragment) => `<SegmentURL media="${fragment.path}" />`).join('')}
               <SegmentTimeline> 
                 ${fragments.map((fragment) => {
                   const duration = (fragment.duration || 0.01) * timescale;
-                  const segment = `<S t="${time}" d="${duration}"></S>`;
+                  const segment = `<S t="${time}" d="${duration}"/>`;
                   time += duration;
                   return segment;
-                })}
+                }).join('')}
               </SegmentTimeline>
             </SegmentList>
           </Representation>

--- a/index.js
+++ b/index.js
@@ -30,9 +30,22 @@ module.exports.PLAYLIST_ARGUMENTS = ['--flat-playlist', '-j'];
 
 const timescale = 48000;
 
+const generateDurationString = (totalSeconds) => {
+  const secondsString = `${totalSeconds % 60}S`;
+
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  const minutes = totalMinutes % 60;
+  const minutesString = minutes > 0 ? `${minutes}M` : '';
+
+  const hours = Math.floor(totalMinutes / 60);
+  const hoursString = hours > 0 ? `${hours}H` : '';
+
+  return `PT${hoursString}${minutesString}${secondsString}`;
+}
+
 const generateManifest = (data) => {
   const { duration, ext, format_id, fragments, fragment_base_url } = data;
-  const durationString = `PT${Math.floor(duration / 60)}M${duration % 60}S`
+  const durationString = generateDurationString(duration);
   let time = 0;
 
   return (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ytdl-process",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Shared module for our youtube-dl processing",
   "main": "index.js"
 }


### PR DESCRIPTION
Make timestamps use hours, minutes, seconds instead of just hours, minutes

We should be able to deploy this to the service and get it fixed relatively quickly.