### PR TITLE
VIVI-9519 Fix incorrect args index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,10 +23,10 @@ module.exports.ARGUMENTS = [
   '--write-auto-sub',
   '--no-playlist',
   '-f', `(${formatPreferences})${commonProperties}`,
-  '-j'
+  '-J'
 ];
 
-module.exports.PLAYLIST_ARGUMENTS = ['--flat-playlist', '-j'];
+module.exports.PLAYLIST_ARGUMENTS = ['--flat-playlist', '-J'];
 
 const timescale = 48000;
 


### PR DESCRIPTION
The ytdl-process package is used by vivi-box and vivi-service-ytdl. These two exports are only used by vivi-box. This change has no impact on vivi-service-ytdl.

`-J` is the correct commandline equivalent of the `forcejson` that is used by `service.py`. 

Using `-j` has no harmful effect when downloading a single video, but breaks things when downloading a playlist. I guess we just never noticed...