### PR TITLE
Allows additional env vars to be specified when starting python server

### DIFF
--- a/index.js
+++ b/index.js
@@ -158,8 +158,8 @@ module.exports.processPlaylist = (output) => {
   return [];
 };
 
-module.exports.spawnPythonService = (additional_env = {}) => {
-  return spawn(join(__dirname, 'service.py'), [], { env: { ...process.env, ...additional_env } });
+module.exports.spawnPythonService = (additionalEnv = {}) => {
+  return spawn(join(__dirname, 'service.py'), [], { env: { ...process.env, ...additionalEnv } });
 }
 
 // private

--- a/index.js
+++ b/index.js
@@ -158,8 +158,8 @@ module.exports.processPlaylist = (output) => {
   return [];
 };
 
-module.exports.spawnPythonService = () => {
-  return spawn(join(__dirname, 'service.py'));
+module.exports.spawnPythonService = (additional_env = {}) => {
+  return spawn(join(__dirname, 'service.py'), [], { env: { ...process.env, ...additional_env } });
 }
 
 // private

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ytdl-process",
-  "version": "1.0.4",
+  "version": "1.0.3",
   "description": "Shared module for our youtube-dl processing",
   "main": "index.js"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ytdl-process",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Shared module for our youtube-dl processing",
   "main": "index.js"
 }


### PR DESCRIPTION
This is needed on GF devices, for the local instance of the ytdl service (used in the local fallback). 

We need to pass in two env vars (http_proxy and https_proxy). Otherwise the local fallback won't work if we are behind a proxy. 

vivi-service-ytdl does not need to be updated (this change is only needed to fix local fallback). 