### PR TITLE
VIVI-10049 have ytdl process send back multiple urls

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,12 +17,23 @@ const formatPreferences = [
   'best[height <=? 720]'
 ].join('/');
 
+const bestAudioPreference = 'bestaudio';
+
 module.exports.ARGUMENTS = [
   '--restrict-filenames',
   '--write-sub',
   '--write-auto-sub',
   '--no-playlist',
   '-f', `(${formatPreferences})${commonProperties}`,
+  '-J'
+];
+
+module.exports.ARGUMENTS_MULTI_FORMAT = [
+  '--restrict-filenames',
+  '--write-sub',
+  '--write-auto-sub',
+  '--no-playlist',
+  '-f', `${bestAudioPreference}${commonProperties}`,
   '-J'
 ];
 

--- a/index.js
+++ b/index.js
@@ -17,8 +17,6 @@ const formatPreferences = [
   'best[height <=? 720]'
 ].join('/');
 
-const bestAudioPreference = 'bestaudio';
-
 module.exports.ARGUMENTS = [
   '--restrict-filenames',
   '--write-sub',
@@ -33,7 +31,7 @@ module.exports.ARGUMENTS_MULTI_FORMAT = [
   '--write-sub',
   '--write-auto-sub',
   '--no-playlist',
-  '-f', `${bestAudioPreference}${commonProperties}`,
+  '-f', `bestaudio${commonProperties}`,
   '-J'
 ];
 
@@ -186,7 +184,7 @@ module.exports.processV3 = (output, origin) => {
     const audioManifest = generateManifest(data);
     processedData.audio = { type: 'manifest', manifest: audioManifest };
   } else {
-    processedData.audio = { type: 'url', audio };
+    processedData.audio = { type: 'url', url: audio };
   }
 
   return {
@@ -232,7 +230,7 @@ function processFormats(formats) {
     const type = fragments ? 'manifest' : 'url';
     const assignedData = type === 'manifest' ? { type, ...format } : { type, url };
 
-    if (format_id === 'source' || vcodec === 'av01' || vcodec === 'vp9') {
+    if (format_id === 'source' || !vcodec || !acodec || vcodec === 'av01' || vcodec.includes('vp9') || vcodec.includes('vp09')) {
       return;
     }
 

--- a/service.py
+++ b/service.py
@@ -49,7 +49,7 @@ class Handler(BaseHTTPRequestHandler):
             'simulate': True
         }
         if url.path == '/process':
-            ydl_opts['format'] = '(best[height = 1080][fps <= 30]/best[height <=? 720])[format_id!=source][vcodec!*=av01][vcodec!*=vp9]'
+            ydl_opts['format'] = 'bestaudio[format_id!=source][vcodec!*=av01][vcodec!*=vp9]'
             ydl_opts['noplaylist'] = True
             ydl_opts['restrictfilenames'] = True
             ydl_opts['writeautomaticsub'] = True

--- a/service.py
+++ b/service.py
@@ -41,7 +41,7 @@ class Handler(BaseHTTPRequestHandler):
     def do_GET(self):
         url = urlparse(self.path)
         qs = parse_qs(url.query)
-        version = qs.get('version')
+        version = qs.get('version', "2")
 
         ydl_opts = {
             'forcejson': True,
@@ -50,7 +50,10 @@ class Handler(BaseHTTPRequestHandler):
             'simulate': True
         }
         if url.path == '/process':
-            ydl_opts['format'] = f'{"bestaudio" if version and version[0] == "3" else "(best[height = 1080][fps <= 30]/best[height <=? 720])"}[format_id!=source][vcodec!*=av01][vcodec!*=vp9]'
+            # The format argument returns a result based on specific format arguments.
+            # Version 2 format arg returns a url for the best 1080p or 720p video.
+            # However for version 3, since all formats are considered, the best audio is requested in the case that audio is needed if a video only track is selected. 
+            ydl_opts['format'] = f'{"bestaudio" if version[0] == "3" else "(best[height = 1080][fps <= 30]/best[height <=? 720])"}[format_id!=source][vcodec!*=av01][vcodec!*=vp9]'
             ydl_opts['noplaylist'] = True
             ydl_opts['restrictfilenames'] = True
             ydl_opts['writeautomaticsub'] = True

--- a/service.py
+++ b/service.py
@@ -41,6 +41,7 @@ class Handler(BaseHTTPRequestHandler):
     def do_GET(self):
         url = urlparse(self.path)
         qs = parse_qs(url.query)
+        version = qs.get('version')
 
         ydl_opts = {
             'forcejson': True,
@@ -49,7 +50,7 @@ class Handler(BaseHTTPRequestHandler):
             'simulate': True
         }
         if url.path == '/process':
-            ydl_opts['format'] = 'bestaudio[format_id!=source][vcodec!*=av01][vcodec!*=vp9]'
+            ydl_opts['format'] = f'{"bestaudio" if version and version[0] == "3" else "(best[height = 1080][fps <= 30]/best[height <=? 720])"}[format_id!=source][vcodec!*=av01][vcodec!*=vp9]'
             ydl_opts['noplaylist'] = True
             ydl_opts['restrictfilenames'] = True
             ydl_opts['writeautomaticsub'] = True


### PR DESCRIPTION
Add a `processV3` method to be able to send back multiple urls for 720p, 1080p and 4k video formats. This method prioritised getting combined urls first (video + audio) but if a combined track for a specific resolution is not available, it just returns the best quality video url. Since there is a high chance especially at 1080p or 4k that a combined track doesn't exist, the V3 method attached an `audio` track as well so it can be used with video only tracks.