### PR TITLE
VIVI-10382 Select best audio with opus codec and filter out https protocol tracks

### DIFF
--- a/service.py
+++ b/service.py
@@ -52,8 +52,9 @@ class Handler(BaseHTTPRequestHandler):
         if url.path == '/process':
             # The format argument returns a result based on specific format arguments.
             # Version 2 format arg returns a url for the best 1080p or 720p video.
-            # However for version 3, since all formats are considered, the best audio is requested in the case that audio is needed if a video only track is selected. 
-            ydl_opts['format'] = f'{"bestaudio" if version[0] == "3" else "(best[height = 1080][fps <= 30]/best[height <=? 720])"}[format_id!=source][vcodec!*=av01][vcodec!*=vp9]'
+            # However for version 3, since all formats are considered, the best audio with opus audio codec is requested in the case that audio is needed if a video only track is selected.
+            # If no audio format with opus audio codec is available, then it defaults to just getting the best audio track.
+            ydl_opts['format'] = f'{"bestaudio[acodec=opus]/bestaudio" if version[0] == "3" else "(best[height = 1080][fps <= 30]/best[height <=? 720])"}[format_id!=source][vcodec!*=av01][vcodec!*=vp9]'
             ydl_opts['noplaylist'] = True
             ydl_opts['restrictfilenames'] = True
             ydl_opts['writeautomaticsub'] = True


### PR DESCRIPTION
Add some more additional filtering to the returned video and audio urls returned from the processV3 method. For the single audio track the best audio with the `opus` codec is returned unless it isn't available in which case the best audio is returned. For video, tracks using the `https` protocol are filtered out and so videos are only going to be either in `m3u8` or `dash` which will work with the split player.