### PR TITLE
VIVI-11014 Filter out unsupported subtitle format

### DIFF
--- a/index.js
+++ b/index.js
@@ -225,7 +225,7 @@ function findBestSubtitleFile(list) {
     .filter((lang) => lang.toString().substring(0,2) === 'en')
     .map((lang) => ({
       lang,
-      subs: list[lang].find((x) => (x.ext === 'vtt' && x.protocol !== 'm3u8_native')),
+      subs: list[lang].find((x) => (x.ext === 'vtt' && x.protocol !== 'http_dash_segments' && x.protocol !== 'm3u8_native')),
       priority: EN_LIST.indexOf(lang)
     }))
     .filter((x) => x.subs)


### PR DESCRIPTION
From https://vivi.atlassian.net/browse/ENG-1112, a customer provided a youtube link that had subtitles in this 'http_dash_segments' format. We can't play subtitles in this format so we should filter it out.

I re-checked the video that the customer provided and the available subtitle tracks no longer includes any `http_dash_segments` tracks. So i can't really replicate the problem. 

However, the way we are handling subtitles... they do still need to be a single file. A list of segments just won't work. 

After merging this PR, someone needs to: 
- update `package.json` in `vivi-service-ytdl` with the new commit hash
- update `package.json` in `vivi-box` with the new commit hash

Both of these projects (vivi-box and vivi-service-ytdl) reference a specific commit of this project.