### PR TITLE
VIVI-11030 Update service.py to use python3 from env var

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ const generateManifest = (data, isAudio = false) => {
                 const path = fragment.path.replace('&', '&amp;');
                 return `<SegmentURL media="${path}" />`;
               }).join('')}
-              <SegmentTimeline> 
+              <SegmentTimeline>
                 ${fragments.map((fragment) => {
                   const duration = (fragment.duration || 0.01) * timescale;
                   const segment = `<S t="${time}" d="${duration}"/>`;
@@ -215,7 +215,7 @@ module.exports.processPlaylist = (output) => {
 };
 
 module.exports.spawnPythonService = (additionalEnv = {}) => {
-  return spawn(join(__dirname, 'service.py'), [], { env: { ...process.env, ...additionalEnv } });
+  return spawn('python3', ['-u', join(__dirname, 'service.py')], { env: { ...process.env, ...additionalEnv } });
 }
 
 // private

--- a/service.py
+++ b/service.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -u
+#!/usr/bin/env python3
 
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from socketserver import ThreadingMixIn


### PR DESCRIPTION
The change to service.py ensures that the script uses the version of Python chosen by the environment.

The change to index.js ensures that the Python process is started with unbuffered output, which was the existing behaviour of the shebang line in service.py.