### PR TITLE
Add PR checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+### Description
+
+Write a description of your PR here
+
+--------
+
+### Checklist
+
+Before merge:
+- [ ] modifications to process, processV2 and processV3 MUST be backwards compatible
+
+After merge checklist:
+- [ ] update commit hash of ytdl-process in vivi-box\app\package.json
+- [ ] update commit hash of ytdl-process in vivi-service-ytdl\package.json


### PR DESCRIPTION
Main purpose is to remind people that they have to manually update two other repos whenever a change is made to this repo. 

Looks like this when opening a PR:
![image](https://github.com/viviedu/ytdl-process/assets/104745979/7a07fbb1-7227-4429-8d91-b5aee4d872c0)

Opened PRs look like this:
![image](https://github.com/viviedu/ytdl-process/assets/104745979/7663ce00-f388-4204-b272-67dbae40876c)
