### PR TITLE
VIVI-12238 Fix vimeo videos being mostly broken

### DIFF
--- a/index.js
+++ b/index.js
@@ -280,6 +280,19 @@ function videoTrackSort(a, b) {
     return 1;
   }
 
+  if (a.format_id.includes('akfire_interconnect') || a.format_id.includes('fastly_skyfire')) {
+    // Vimeo video!
+    // If one has 'sep' in the format_id and one does not, we take the one with 'sep' in its format_id
+    // VIVI-12238: video tracks that don't have '_sep' in its format_id are sometimes failing, reasons unknown
+    if (a.format_id.includes('_sep') && !b.format_id.includes('_sep')) {
+      return -1;
+    }
+    
+    if (!a.format_id.includes('_sep') && b.format_id.includes('_sep')) {
+      return 1;
+    }
+  }
+
   // Then prefer non-dash tracks. (Dash = manifest xml. Non-dash = a link that can be easily tested in a browser)
   if (a.protocol !== 'dash' && b.protocol === 'dash') {
     return -1;

--- a/tests/test.js
+++ b/tests/test.js
@@ -16,32 +16,39 @@ test('generateDurationString generates correct strings', () => {
 
 // Ensure sorting criteria works as we expect
 test('videoTrackSort prefers higher resolutions', () => {
-    const a = { format_id: 'aaa', height: 720, acodec: 'opus', protocol: 'm3u8', tbr: 1000 };
-    const b = { format_id: 'bbb', height: 2180, acodec: 'none', protocol: 'dash', tbr: 3000 };
+    const a = { format_id: 'hls-akfire_interconnect_quic_sep-2519', height: 720, acodec: 'opus', protocol: 'm3u8', tbr: 1000 };
+    const b = { format_id: 'hls-akfire_interconnect_quic-2325', height: 2180, acodec: 'none', protocol: 'dash', tbr: 3000 };
     expect([a, b].sort(videoTrackSort)[0]).toBe(b);
     expect([b, a].sort(videoTrackSort)[0]).toBe(b);
 });
 
 test('videoTrackSort prefers combined video/audio tracks', () => {
-    const a = { format_id: 'aaa', height: 1080, acodec: 'opus', protocol: 'dash', tbr: 1000 };
-    const b = { format_id: 'bbb', height: 1080, acodec: 'none', protocol: 'm3u8', tbr: 3000 };
+    const a = { format_id: 'hls-akfire_interconnect_quic-2325', height: 1080, acodec: 'opus', protocol: 'dash', tbr: 1000 };
+    const b = { format_id: 'hls-akfire_interconnect_quic_sep-2519', height: 1080, acodec: 'none', protocol: 'm3u8', tbr: 3000 };
     expect([a, b].sort(videoTrackSort)[0]).toBe(a);
     expect([b, a].sort(videoTrackSort)[0]).toBe(a);
 
-    const c = { format_id: 'ccc', height: 1080, acodec: 'none', protocol: 'dash', tbr: 1000 };
-    const d = { format_id: 'ddd', height: 1080, acodec: 'opus', protocol: 'm3u8', tbr: 3000 };
+    const c = { format_id: 'hls-akfire_interconnect_quic-2325', height: 1080, acodec: 'none', protocol: 'dash', tbr: 1000 };
+    const d = { format_id: 'hls-akfire_interconnect_quic_sep-2519', height: 1080, acodec: 'opus', protocol: 'm3u8', tbr: 3000 };
     expect([c, d].sort(videoTrackSort)[0]).toBe(d);
     expect([d, c].sort(videoTrackSort)[0]).toBe(d);
 });
 
+test('videoTrackSort prefers vimeo tracks with "_sep" in its format_id', () => {
+    const a = { format_id: 'hls-akfire_interconnect_quic_sep-2519', height: 1080, acodec: 'none', protocol: 'dash', tbr: 1000 };
+    const b = { format_id: 'hls-akfire_interconnect_quic-2325', height: 1080, acodec: 'none', protocol: 'm3u8', tbr: 3000 };
+    expect([a, b].sort(videoTrackSort)[0]).toBe(a);
+    expect([b, a].sort(videoTrackSort)[0]).toBe(a);
+});
+
 test('videoTrackSort prefers url tracks over dash tracks', () => {
-    const a = { format_id: 'aaa', height: 1080, acodec: 'opus', protocol: 'dash', tbr: 1000 };
-    const b = { format_id: 'bbb', height: 1080, acodec: 'opus', protocol: 'm3u8', tbr: 3000 };
+    const a = { format_id: '22', height: 1080, acodec: 'opus', protocol: 'dash', tbr: 1000 };
+    const b = { format_id: '22', height: 1080, acodec: 'opus', protocol: 'm3u8', tbr: 3000 };
     expect([a, b].sort(videoTrackSort)[0]).toBe(b);
     expect([b, a].sort(videoTrackSort)[0]).toBe(b);
 
-    const c = { format_id: 'ccc', height: 1080, acodec: 'none', protocol: 'm3u8', tbr: 3000 };
-    const d = { format_id: 'ddd', height: 1080, acodec: 'none', protocol: 'dash', tbr: 3000 };
+    const c = { format_id: 'hls-akfire_interconnect_quic-2325', height: 1080, acodec: 'none', protocol: 'm3u8', tbr: 3000 };
+    const d = { format_id: 'hls-akfire_interconnect_quic-2325', height: 1080, acodec: 'none', protocol: 'dash', tbr: 3000 };
     expect([c, d].sort(videoTrackSort)[0]).toBe(c);
     expect([d, c].sort(videoTrackSort)[0]).toBe(c);
 });


### PR DESCRIPTION
### Description

Whenever we have two tracks with the same stats, but one has 'sep' in the name and one does not, always pick the one with sep in its name. 

This addresses the issue where many vimeo videos are no longer playing on signage or play content. 

For many vimeo videos, some of their tracks are bad. I have no idea why, but the pattern seems to be that tracks with "sep" in its name are good. 

e.g. example of one such video, screenshot of output from my script
![image](https://github.com/viviedu/ytdl-process/assets/104745979/4010bca8-3b6e-497b-b768-aa1b885d71f5)

--------

### Checklist

Before merge:
- [x] modifications to process, processV2 and processV3 MUST be backwards compatible

After merge checklist:
- [ ] update commit hash of ytdl-process in vivi-box\app\package.json
- [ ] update commit hash of ytdl-process in vivi-service-ytdl\package.json
