### PR TITLE
VIVI-12740 Extract additional combined tracks

### DIFF
--- a/service.py
+++ b/service.py
@@ -59,6 +59,11 @@ class Handler(BaseHTTPRequestHandler):
             ydl_opts['restrictfilenames'] = True
             ydl_opts['writeautomaticsub'] = True
             ydl_opts['writesubtitles'] = True
+
+            # by default, yt-dlp queries each url twice, once as an ios client and once as a web client. Youtube returns different tracks to
+            # different clients. We add 'mediaconnect' to the list, because this causes youtube to return combined 720p/1080p m3u8 tracks which
+            # are handy to have. More clients = hitting youtube more times. This option is ignored by yt-dlp for URLs that are not youtube.
+            ydl_opts['extractor_args'] = {'youtube': {'player_client': ['ios', 'web', 'mediaconnect']}}
         elif url.path == '/process_playlist':
             ydl_opts['extract_flat'] = True
         else:


### PR DESCRIPTION
### Description

Tested my changes against v3.7.5 on IMX and GF to confirm that my changes to V3 are backwards compatible. 

Play Content - no change, same tracks as before will be selected by box and played
Signage - this PR causes ytdl to return additional combined tracks, which signage can use
Vivi Anywhere - matt tested

--------

### Checklist

Before merge:
- [x] modifications to process, processV2 and processV3 MUST be backwards compatible

After merge checklist:
- [ ] update commit hash of ytdl-process in vivi-box\app\package.json
- [ ] update commit hash of ytdl-process in vivi-service-ytdl\package.json
