### PR TITLE
VIVI-12899 Change youtube clients to ios,web_creator,mediaconnect

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports.ARGUMENTS_MULTI_FORMAT = [
   '--write-auto-sub',
   '--no-playlist',
   '-f', `bestaudio[acodec=opus]/bestaudio`,
-  '--extractor-args', `youtube:player-client=ios,web,mediaconnect`,
+  '--extractor-args', `youtube:player-client=ios,web_creator,mediaconnect`,
   '-J'
 ];
 
@@ -257,7 +257,16 @@ function processFormats(formats) {
   // Sort the tracks because .find will return the first match
   filteredFormats.sort(videoTrackSort)
 
-  // For each quality level, return at most 1x combined track and 1x video only treack
+  // If you change track selection, then all permutations of the following should ideally be tested:
+  //    - signage, play content
+  //    - youtube livestream, youtube regular video
+  //    - real device (IMX or GF, either is fine), vivi anywhere
+  //
+  // So the above results in 8x permutations
+  // Also, check that:
+  //  - subtitles still work
+  //  - play/pausing and seeking in play content still works
+
   const tracks = []
   for (const quality of [2160, 1080, 720]) {
     tracks.push(filteredFormats.find((format) => (format.height === quality && format.acodec === 'none')));

--- a/service.py
+++ b/service.py
@@ -63,7 +63,7 @@ class Handler(BaseHTTPRequestHandler):
             # by default, yt-dlp queries each url twice, once as an ios client and once as a web client. Youtube returns different tracks to
             # different clients. We add 'mediaconnect' to the list, because this causes youtube to return combined 720p/1080p m3u8 tracks which
             # are handy to have. More clients = hitting youtube more times. This option is ignored by yt-dlp for URLs that are not youtube.
-            ydl_opts['extractor_args'] = {'youtube': {'player_client': ['ios', 'web', 'mediaconnect']}}
+            ydl_opts['extractor_args'] = {'youtube': {'player_client': ['ios', 'web_creator', 'mediaconnect']}}
         elif url.path == '/process_playlist':
             ydl_opts['extract_flat'] = True
         else:


### PR DESCRIPTION
### Description

We are currently getting some errors that indicate youtube is throttling us. 

I looked at the yt-dlp repo, and there's a PR that the community has already approved which changes the default args from "ios,web" to "ios,web_creator". 

So I want to change the args we are using and use web_creator instead of web. Hoping this will alleviate some of the throttling issues our ytdl-service is currently running into. 

--------

### Checklist

Before merge:
- [x] modifications to process, processV2 and processV3 MUST be backwards compatible

After merge checklist:
- [ ] update commit hash of ytdl-process in vivi-box\app\package.json
- [ ] update commit hash of ytdl-process in vivi-service-ytdl\package.json
