### PR TITLE
VIVI-13373 fix resolutions so portrait videos work

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,6 @@ module.exports.ARGUMENTS_MULTI_FORMAT = [
   '--write-sub',
   '--write-auto-sub',
   '--no-playlist',
-  '-f', 'bestaudio[acodec=opus]/bestaudio',
   '--extractor-args', 'youtube:player-client=ios,web_creator,mediaconnect',
   '-J'
 ];
@@ -248,8 +247,15 @@ module.exports.processV4 = (output, origin, locales = []) => {
     }
   });
 
-  // In V4 we just return all the eligible audio tracks and let the box pick
-  // This is so that gstreamer can pick a m3u8 track and Vivi Anywhere can pick a non-m3u8 track
+  // In V4 we just return all the eligible audio tracks and let the box pick.
+  //
+  // The three most common kinds of audio tracks:
+  //  1) proto=https acodec=opus: ok on Vivi Display, ok on physical devices
+  //  2) proto=https acodec=mp4a: ok on Vivi Display, cannot be played on physical devices
+  //  3) proto=m3u8 acodec=unknown: cannot be played on Vivi Display, ok on phyiscal devices
+  //
+  // Type 1 is the best. There are (very rarely) youtube videos that do not have this kind of track.
+  // Just return everything and let vivi-box pick, it knows whether it's on a Vivi Display or on a physical device
   const formattedTracks = audioTracks.map(audioTrack => {
     const { acodec, fragments: audio_fragments, url: audio_url, format_id: audio_format, abr: audio_bitrate, protocol: audio_protocol, language } = audioTrack;
     const audio_language = language || 'unknown';
@@ -416,7 +422,7 @@ function filterVideoFormatFps(format) {
 
 function processAudioFormats(formats, returnMultiple = false) {
   // Filter out tracks that are not suitable (see comments below)
-  const filteredFormats = formats.filter((format) => filterAudioFormatCodecs(format));
+  const filteredFormats = formats.filter((format) => filterAudioFormatCodecs(format, returnMultiple));
   // Sort the tracks because .find will return the first match
   filteredFormats.sort(audioTrackSort);
 
@@ -427,8 +433,8 @@ function processAudioFormats(formats, returnMultiple = false) {
   return filteredFormats.length ? filteredFormats[0] : null;
 }
 
-function filterAudioFormatCodecs(format) {
-  const { acodec, audio_ext, abr, protocol, _language } = format;
+function filterAudioFormatCodecs(format, returnMultiple) {
+  const { acodec, audio_ext, abr, protocol, vcodec } = format;
 
   // Audio tracks that are m3u8 have audio_ext set, but acodec and abr are undefined. For some reason yt-dlp can't determine acodec and abr in these situations
   if (acodec && acodec === 'none') {
@@ -441,9 +447,15 @@ function filterAudioFormatCodecs(format) {
     return false;
   }
 
-  // Tracks with protocol=https and acodec=mp4a are no good, because our gstreamer split playing pipeline
-  // can't seek on these tracks. I don't know why, seek succeeds but nothing happens.
-  if (protocol.includes('https') && acodec && acodec.includes('mp4a')) {
+  // Don't return combined audio/video tracks here
+  // (audio tracks = audio only, video tracks = may or may not be a combined track)
+  if (vcodec && vcodec !== 'none') {
+    return false;
+  }
+
+  // Tracks with protocol=https and acodec=mp4a are no good on physical Vivi devices.
+  // If we are V4 (returnMultiple=true), return these and vivi-box code will know not to use it for a physical device.
+  if ((protocol.includes('https') && acodec && acodec.includes('mp4a')) && !returnMultiple) {
     return false;
   }
 

--- a/package.json
+++ b/package.json
@@ -5,11 +5,13 @@
   "main": "index.js",
   "devDependencies": {
     "eslint": "^8",
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "request": "^2.87.0"
   },
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "test": "jest"
+    "test": "jest",
+    "test-track-selection": "node tests/track_selection_test_script"
   }
 }

--- a/service.py
+++ b/service.py
@@ -50,11 +50,12 @@ class Handler(BaseHTTPRequestHandler):
             'simulate': True
         }
         if url.path == '/process':
-            # The format argument returns a result based on specific format arguments.
-            # Version 2 format arg returns a url for the best 1080p or 720p video.
-            # However for version 3, since all formats are considered, the best audio with opus audio codec is requested in the case that audio is needed if a video only track is selected.
-            # If no audio format with opus audio codec is available, then it defaults to just getting the best audio track.
-            ydl_opts['format'] = f'{"bestaudio[acodec=opus]/bestaudio" if version[0] == "3" else "(best[height = 1080][fps <= 30]/best[height <=? 720])"}[format_id!=source][vcodec!*=av01][vcodec!*=vp9]'
+
+            # Version 2 and 1: use a format specifier that asks for the best 1080p or 720p video.
+            # Version 3 and 4: don't use this arg. javascript code will look through all available tracks and pick
+            if version[0] == "2" or version[0] == "1":
+                ydl_opts['format'] = "(best[height = 1080][fps <= 30]/best[height <=? 720])[format_id!=source][vcodec!*=av01][vcodec!*=vp9]"
+
             ydl_opts['noplaylist'] = True
             ydl_opts['restrictfilenames'] = True
             ydl_opts['writeautomaticsub'] = True

--- a/tests/test.js
+++ b/tests/test.js
@@ -134,18 +134,20 @@ test('filterAudioFormatCodecs filters out non-audio tracks', () => {
   expect(Boolean(filterAudioFormatCodecs(audio3))).toBe(true);
 });
 
-test('filterAudioFormatCodecs filters out https/mp4a tracks', () => {
+test('filterAudioFormatCodecs filters out https/mp4a tracks for v3 (returnMultiple=false), but not for v4 (returnMultiple=true)', () => {
   const good1 = { format_id: '250', acodec: 'opus', protocol: 'https', abr: 64000 };
-  expect(Boolean(filterAudioFormatCodecs(good1))).toBe(true);
+  expect(Boolean(filterAudioFormatCodecs(good1, false))).toBe(true);
 
   const good2 = { format_id: '250', acodec: 'mp4a.40.3', protocol: 'm3u8_native', abr: 64000 };
-  expect(Boolean(filterAudioFormatCodecs(good2))).toBe(true);
+  expect(Boolean(filterAudioFormatCodecs(good2, false))).toBe(true);
 
   const good3 = { format_id: '250', protocol: 'm3u8_native', abr: 64000 };
-  expect(Boolean(filterAudioFormatCodecs(good3))).toBe(true);
+  expect(Boolean(filterAudioFormatCodecs(good3, false))).toBe(true);
 
   const bad = { format_id: '250', acodec: 'mp4a.40.5', protocol: 'https', abr: 64000 };
-  expect(Boolean(filterAudioFormatCodecs(bad))).toBe(false);
+  expect(Boolean(filterAudioFormatCodecs(bad, false))).toBe(false);
+  expect(Boolean(filterAudioFormatCodecs(bad, true))).toBe(true);
+  
 });
 
 test('audioTrackSort prefers opus', () => {

--- a/tests/test.js
+++ b/tests/test.js
@@ -19,7 +19,7 @@ test('generateDurationString generates correct strings', () => {
 // Ensure sorting criteria works as we expect
 test('videoTrackSort prefers higher resolutions', () => {
   const a = { format_id: 'hls-akfire_interconnect_quic_sep-2519', height: 720, acodec: 'opus', protocol: 'm3u8', tbr: 1000 };
-  const b = { format_id: 'hls-akfire_interconnect_quic-2325', height: 2180, acodec: 'none', protocol: 'm3u8', tbr: 3000 };
+  const b = { format_id: 'hls-akfire_interconnect_quic-2325', height: 2180, acodec: 'none', protocol: 'dash', tbr: 3000 };
   expect([a, b].sort(videoTrackSort)[0]).toBe(b);
   expect([b, a].sort(videoTrackSort)[0]).toBe(b);
 });
@@ -45,7 +45,7 @@ test('videoTrackSort prefers vimeo tracks with "_sep" in its format_id', () => {
 
 test('videoTrackSort prefers url tracks over dash tracks', () => {
   const a = { format_id: '22', height: 1080, acodec: 'opus', protocol: 'dash', tbr: 1000 };
-  const b = { format_id: '22', height: 720, acodec: 'opus', protocol: 'm3u8', tbr: 3000 };
+  const b = { format_id: '22', height: 1080, acodec: 'opus', protocol: 'm3u8', tbr: 3000 };
   expect([a, b].sort(videoTrackSort)[0]).toBe(b);
   expect([b, a].sort(videoTrackSort)[0]).toBe(b);
 

--- a/tests/track_selection_test_script.js
+++ b/tests/track_selection_test_script.js
@@ -1,0 +1,96 @@
+const { processV4, processV3, spawnPythonService } = require('./../index');
+const { promisify } = require('util');
+const request = require('request');
+
+if (process.argv.length < 3) {
+    console.error("\n\nERROR: Must provide one url.")
+    console.error("e.g.      yarn test-track-selection https://www.youtubodybe.com/watch?v=_lsC0aXyY6g\n\n")
+    process.exit(-1)
+}
+
+const doGetRequest = async (uri) => {
+    const response = await promisify(request)({
+      timeout: 15000,
+      uri
+    });
+    const { body, statusCode } = response || {};
+  
+    if (statusCode >= 400) {
+      log.warn('request failed', { statusCode });
+      throw body;
+    }
+    return body;
+  };
+
+async function main() {
+    const url = process.argv[2]
+
+    spawnPythonService()
+    const body = await doGetRequest(`http://127.0.0.1:4444/process?url=${url}`);
+    const result_3 = processV3(body, '');
+    const result_4 = processV4(body, '');
+
+    // 'body' contains a list of ALL available tracks for this video
+    // result_3 and result_4 are the tracks that processV3 and processV4 have selected
+
+    // Dump the list of all tracks, then dump the list of tracks we selected. 
+
+    const data = JSON.parse(body.toString().trim());
+    console.log("\n\n=============================================================================================================");
+    console.log(`using with yt-dlp v${data._version.version}...\n`);
+    console.log(`Url: ${url}`);
+    console.log(`Title: ${data.title}`);
+    console.log(`Duration: ${data.duration}s`);
+    console.log(`Language: ${data.language}`);
+
+    console.log(`\n\nID            EXT     RESOLUTION   FPS   | PROTO                | VCODEC                           ACODEC       `)
+    console.log(`----------------------------------------------------------------------------------------------------------------`)
+    data.formats.forEach((track) => {
+        format_id = track.format_id.padEnd(13, ' ')
+        ext = track.ext.padEnd(7, ' ')
+        resolution = track.resolution.padEnd(12, ' ')
+        fps = (['none', 'undefined'].includes(track.vcodec) ? '' : `${track.fps}`).padEnd(5, ' ')
+        protocol = track.protocol.padEnd(20, ' ')
+        vcodec = (['none', 'undefined'].includes(track.vcodec) ? '' : `${track.vcodec}`).padEnd(32, ' ')
+        acodec = (['none', 'undefined'].includes(track.acodec) ? '' : `${track.acodec}`).padEnd(12, ' ')
+        console.log(`${format_id} ${ext} ${resolution} ${fps} | ${protocol} | ${vcodec} ${acodec}`)
+    })
+
+    console.log('\nV3 Audio Tracks:')
+    if (result_3.audio) {
+        console.log(`\tid=${result_3.audio.format_id}   language=${result_3.audio.language} type=${result_3.audio.type} protocol=${result_3.audio.protocol}`)
+    }
+
+    console.log('\nV3 Video Tracks:')
+    result_3.video.forEach((track) => {
+        id = `${track.format_id}`.padEnd(12, ' ')
+        height = `${track.height}`.padEnd(8, ' ')
+        combined = `${track.combined}`.padEnd(7, ' ')
+        type = `${track.type}`.padEnd(10, ' ')
+        protocol = `${track.protocol}`.padEnd(20, ' ')
+        console.log(`\tid=${id} height=${height} combined=${combined} type=${type} protocol=${protocol}`)
+    })
+
+    console.log('\nV4 Audio Tracks:')
+    result_4.audio.forEach((track) => {
+        id = `${track.format_id}`.padEnd(12, ' ')
+        language = `${track.language}`.padEnd(6, ' ')
+        type = `${track.type}`.padEnd(10, ' ')
+        protocol = `${track.protocol}`.padEnd(20, ' ')
+        console.log(`\tid=${id} language=${language} type=${type} protocol=${protocol}`)
+    })
+
+    console.log('\nV4 Video Tracks:')
+    result_4.video.forEach((track) => {
+        id = `${track.format_id}`.padEnd(12, ' ')
+        height = `${track.height}`.padEnd(8, ' ')
+        combined = `${track.combined}`.padEnd(7, ' ')
+        type = `${track.type}`.padEnd(10, ' ')
+        protocol = `${track.protocol}`.padEnd(20, ' ')
+        console.log(`\tid=${id} height=${height} combined=${combined} type=${type} protocol=${protocol}`)
+    })
+
+    console.log("\n\n=============================================================================================================");
+}
+
+main();

--- a/tests/track_selection_test_script.js
+++ b/tests/track_selection_test_script.js
@@ -3,94 +3,99 @@ const { promisify } = require('util');
 const request = require('request');
 
 if (process.argv.length < 3) {
-    console.error("\n\nERROR: Must provide one url.")
-    console.error("e.g.      yarn test-track-selection https://www.youtubodybe.com/watch?v=_lsC0aXyY6g\n\n")
-    process.exit(-1)
+  console.error('\n\nERROR: Must provide one url.');
+  console.error('e.g.      yarn test-track-selection https://www.youtubodybe.com/watch?v=_lsC0aXyY6g\n\n');
+  process.exit(-1);
 }
 
 const doGetRequest = async (uri) => {
-    const response = await promisify(request)({
-      timeout: 15000,
-      uri
-    });
-    const { body, statusCode } = response || {};
-  
-    if (statusCode >= 400) {
-      log.warn('request failed', { statusCode });
-      throw body;
-    }
-    return body;
-  };
+  const response = await promisify(request)({
+    timeout: 15000,
+    uri
+  });
+  const { body, statusCode } = response || {};
+
+  if (statusCode >= 400) {
+    console.error('request failed', { statusCode });
+    throw body;
+  }
+  return body;
+};
 
 async function main() {
-    const url = process.argv[2]
+  const url = process.argv[2];
 
-    spawnPythonService()
-    const body = await doGetRequest(`http://127.0.0.1:4444/process?url=${url}`);
-    const result_3 = processV3(body, '');
-    const result_4 = processV4(body, '');
+  spawnPythonService();
 
-    // 'body' contains a list of ALL available tracks for this video
-    // result_3 and result_4 are the tracks that processV3 and processV4 have selected
+  // If this line fails on windows, you need to spawn the python process yourself
+  // run `PATH_TO_PYTHON_EXECUTABLE -u service.py` in another window and leave it running
+  const body = await doGetRequest(`http://127.0.0.1:4444/process?url=${url}&version=4`);
 
-    // Dump the list of all tracks, then dump the list of tracks we selected. 
+  const result_3 = processV3(body, '');
+  const result_4 = processV4(body, '');
 
-    const data = JSON.parse(body.toString().trim());
-    console.log("\n\n=============================================================================================================");
-    console.log(`using with yt-dlp v${data._version.version}...\n`);
-    console.log(`Url: ${url}`);
-    console.log(`Title: ${data.title}`);
-    console.log(`Duration: ${data.duration}s`);
-    console.log(`Language: ${data.language}`);
+  // 'body' contains a list of ALL available tracks for this video
+  // result_3 and result_4 are the tracks that processV3 and processV4 have selected
 
-    console.log(`\n\nID            EXT     RESOLUTION   FPS   | PROTO                | VCODEC                           ACODEC       `)
-    console.log(`----------------------------------------------------------------------------------------------------------------`)
-    data.formats.forEach((track) => {
-        format_id = track.format_id.padEnd(13, ' ')
-        ext = track.ext.padEnd(7, ' ')
-        resolution = track.resolution.padEnd(12, ' ')
-        fps = (['none', 'undefined'].includes(track.vcodec) ? '' : `${track.fps}`).padEnd(5, ' ')
-        protocol = track.protocol.padEnd(20, ' ')
-        vcodec = (['none', 'undefined'].includes(track.vcodec) ? '' : `${track.vcodec}`).padEnd(32, ' ')
-        acodec = (['none', 'undefined'].includes(track.acodec) ? '' : `${track.acodec}`).padEnd(12, ' ')
-        console.log(`${format_id} ${ext} ${resolution} ${fps} | ${protocol} | ${vcodec} ${acodec}`)
-    })
+  // Dump the list of all tracks, then dump the list of tracks we selected. 
 
-    console.log('\nV3 Audio Tracks:')
-    if (result_3.audio) {
-        console.log(`\tid=${result_3.audio.format_id}   language=${result_3.audio.language} type=${result_3.audio.type} protocol=${result_3.audio.protocol}`)
-    }
+  const data = JSON.parse(body.toString().trim());
+  console.log('\n\n=============================================================================================================');
+  console.log(`using with yt-dlp v${data._version.version}...\n`);
+  console.log(`Url: ${url}`);
+  console.log(`Title: ${data.title}`);
+  console.log(`Duration: ${data.duration}s`);
+  console.log(`Language: ${data.language}`);
 
-    console.log('\nV3 Video Tracks:')
-    result_3.video.forEach((track) => {
-        id = `${track.format_id}`.padEnd(12, ' ')
-        height = `${track.height}`.padEnd(8, ' ')
-        combined = `${track.combined}`.padEnd(7, ' ')
-        type = `${track.type}`.padEnd(10, ' ')
-        protocol = `${track.protocol}`.padEnd(20, ' ')
-        console.log(`\tid=${id} height=${height} combined=${combined} type=${type} protocol=${protocol}`)
-    })
+  console.log('\n\nID            EXT     RESOLUTION   FPS   | PROTO                | VCODEC                           ACODEC       ');
+  console.log('----------------------------------------------------------------------------------------------------------------');
+  data.formats.forEach((track) => {
+    const format_id = track.format_id.padEnd(13, ' ');
+    const ext = track.ext.padEnd(7, ' ');
+    const resolution = track.resolution.padEnd(12, ' ');
+    const fps = (['none', 'undefined'].includes(track.vcodec) ? '' : `${track.fps}`).padEnd(5, ' ');
+    const protocol = track.protocol.padEnd(20, ' ');
+    const vcodec = (['none', 'undefined'].includes(track.vcodec) ? '' : `${track.vcodec}`).padEnd(32, ' ');
+    const acodec = (['none', 'undefined'].includes(track.acodec) ? '' : `${track.acodec}`).padEnd(12, ' ');
+    console.log(`${format_id} ${ext} ${resolution} ${fps} | ${protocol} | ${vcodec} ${acodec}`);
+  });
 
-    console.log('\nV4 Audio Tracks:')
-    result_4.audio.forEach((track) => {
-        id = `${track.format_id}`.padEnd(12, ' ')
-        language = `${track.language}`.padEnd(6, ' ')
-        type = `${track.type}`.padEnd(10, ' ')
-        protocol = `${track.protocol}`.padEnd(20, ' ')
-        console.log(`\tid=${id} language=${language} type=${type} protocol=${protocol}`)
-    })
+  console.log('\nV3 Audio Tracks:');
+  if (result_3.audio) {
+    console.log(`\tid=${result_3.audio.format_id}   language=${result_3.audio.language} type=${result_3.audio.type} protocol=${result_3.audio.protocol}`);
+  }
 
-    console.log('\nV4 Video Tracks:')
-    result_4.video.forEach((track) => {
-        id = `${track.format_id}`.padEnd(12, ' ')
-        height = `${track.height}`.padEnd(8, ' ')
-        combined = `${track.combined}`.padEnd(7, ' ')
-        type = `${track.type}`.padEnd(10, ' ')
-        protocol = `${track.protocol}`.padEnd(20, ' ')
-        console.log(`\tid=${id} height=${height} combined=${combined} type=${type} protocol=${protocol}`)
-    })
+  console.log('\nV3 Video Tracks:');
+  result_3.video.forEach((track) => {
+    const id = `${track.format_id}`.padEnd(12, ' ');
+    const height = `${track.height}`.padEnd(8, ' ');
+    const combined = `${track.combined}`.padEnd(7, ' ');
+    const type = `${track.type}`.padEnd(10, ' ');
+    const protocol = `${track.protocol}`.padEnd(20, ' ');
+    console.log(`\tid=${id} height=${height} combined=${combined} type=${type} protocol=${protocol}`);
+  });
 
-    console.log("\n\n=============================================================================================================");
+  console.log('\nV4 Audio Tracks:');
+  result_4.audio.forEach((track) => {
+    const id = `${track.format_id}`.padEnd(12, ' ');
+    const language = `${track.language}`.padEnd(6, ' ');
+    const acodec = `${track.acodec}`.padEnd(10, ' ');
+    const type = `${track.type}`.padEnd(10, ' ');
+    const protocol = `${track.protocol}`.padEnd(20, ' ');
+    console.log(`\tid=${id} language=${language} acodec=${acodec} type=${type} protocol=${protocol}`);
+  });
+
+  console.log('\nV4 Video Tracks:');
+  result_4.video.forEach((track) => {
+    const id = `${track.format_id}`.padEnd(12, ' ');
+    const height = `${track.height}`.padEnd(8, ' ');
+    const combined = `${track.combined}`.padEnd(7, ' ');
+    const type = `${track.type}`.padEnd(10, ' ');
+    const protocol = `${track.protocol}`.padEnd(20, ' ');
+    console.log(`\tid=${id} height=${height} combined=${combined} type=${type} protocol=${protocol}`);
+  });
+
+  console.log('\n\n=============================================================================================================');
 }
 
 main();

--- a/yarn.lock
+++ b/yarn.lock
@@ -727,7 +727,7 @@ acorn@^8.9.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.12.1.tgz#71616bdccbe25e27a54439e0046e89ca76df2248"
   integrity sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==
 
-ajv@^6.12.4:
+ajv@^6.12.3, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -787,6 +787,33 @@ argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
+asn1@~0.2.3:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.6.tgz#0d3a7bb6e64e02a90c0303b31f292868ea09a08d"
+  integrity sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==
+  dependencies:
+    safer-buffer "~2.1.0"
+
+assert-plus@1.0.0, assert-plus@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
+  integrity sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==
+
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
+aws-sign2@~0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
+  integrity sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==
+
+aws4@^1.8.0:
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.13.2.tgz#0aa167216965ac9474ccfa83892cfb6b3e1e52ef"
+  integrity sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==
 
 babel-jest@^29.7.0:
   version "29.7.0"
@@ -853,6 +880,13 @@ balanced-match@^1.0.0:
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+bcrypt-pbkdf@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
+  integrity sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==
+  dependencies:
+    tweetnacl "^0.14.3"
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -909,6 +943,11 @@ caniuse-lite@^1.0.30001587:
   version "1.0.30001609"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001609.tgz#fc34fad75c0c6d6d6303bdbceec2da8f203dabd6"
   integrity sha512-JFPQs34lHKx1B5t1EpQpWH4c+29zIyn/haGsbpfq3suuV9v56enjFt23zqijxGTMwy1p/4H2tjnQMY+p1WoAyA==
+
+caseless@~0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
+  integrity sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==
 
 chalk@^2.4.2:
   version "2.4.2"
@@ -985,6 +1024,13 @@ color-name@~1.1.4:
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+combined-stream@^1.0.6, combined-stream@~1.0.6:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -994,6 +1040,11 @@ convert-source-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
+
+core-util-is@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+  integrity sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==
 
 create-jest@^29.7.0:
   version "29.7.0"
@@ -1016,6 +1067,13 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+dashdash@^1.12.0:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
+  integrity sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==
+  dependencies:
+    assert-plus "^1.0.0"
 
 debug@^4.1.0, debug@^4.1.1, debug@^4.3.1:
   version "4.3.4"
@@ -1046,6 +1104,11 @@ deepmerge@^4.2.2:
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
   integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
 
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
+
 detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
@@ -1062,6 +1125,14 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+ecc-jsbn@~0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
+  integrity sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==
+  dependencies:
+    jsbn "~0.1.0"
+    safer-buffer "^2.1.0"
 
 electron-to-chromium@^1.4.668:
   version "1.4.735"
@@ -1231,6 +1302,21 @@ expect@^29.7.0:
     jest-message-util "^29.7.0"
     jest-util "^29.7.0"
 
+extend@~3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
+
+extsprintf@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
+  integrity sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==
+
+extsprintf@^1.2.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.1.tgz#8d172c064867f235c0c84a596806d279bf4bcc07"
+  integrity sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -1304,6 +1390,20 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.1.tgz#21db470729a6734d4997002f439cb308987f567a"
   integrity sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==
 
+forever-agent@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
+  integrity sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==
+
+form-data@~2.3.2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
+  integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.6"
+    mime-types "^2.1.12"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
@@ -1338,6 +1438,13 @@ get-stream@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
+
+getpass@^0.1.1:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
+  integrity sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==
+  dependencies:
+    assert-plus "^1.0.0"
 
 glob-parent@^6.0.2:
   version "6.0.2"
@@ -1380,6 +1487,19 @@ graphemer@^1.4.0:
   resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
+har-schema@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
+  integrity sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==
+
+har-validator@~5.1.3:
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.5.tgz#1f0803b9f8cb20c0fa13822df1ecddb36bde1efd"
+  integrity sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==
+  dependencies:
+    ajv "^6.12.3"
+    har-schema "^2.0.0"
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -1401,6 +1521,15 @@ html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
+
+http-signature@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
+  integrity sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==
+  dependencies:
+    assert-plus "^1.0.0"
+    jsprim "^1.2.2"
+    sshpk "^1.7.0"
 
 human-signals@^2.1.0:
   version "2.1.0"
@@ -1495,10 +1624,20 @@ is-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
   integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
 
+is-typedarray@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
+  integrity sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==
+
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
+
+isstream@~0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
+  integrity sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==
 
 istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
   version "3.2.2"
@@ -1931,6 +2070,11 @@ js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
+jsbn@~0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
+  integrity sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==
+
 jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
@@ -1951,15 +2095,35 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
+json-schema@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
+  integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
+
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
+json-stringify-safe@~5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
+  integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
+
 json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
+
+jsprim@^1.2.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.2.tgz#712c65533a15c878ba59e9ed5f0e26d5b77c5feb"
+  integrity sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==
+  dependencies:
+    assert-plus "1.0.0"
+    extsprintf "1.3.0"
+    json-schema "0.4.0"
+    verror "1.10.0"
 
 keyv@^4.5.3:
   version "4.5.4"
@@ -2051,6 +2215,18 @@ micromatch@^4.0.4:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12, mime-types@~2.1.19:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
@@ -2094,6 +2270,11 @@ npm-run-path@^4.0.1:
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   dependencies:
     path-key "^3.0.0"
+
+oauth-sign@~0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
+  integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
 once@^1.3.0:
   version "1.4.0"
@@ -2191,6 +2372,11 @@ path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
+performance-now@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
+  integrity sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==
+
 picocolors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
@@ -2235,7 +2421,12 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-punycode@^2.1.0:
+psl@^1.1.28:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
+  integrity sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==
+
+punycode@^2.1.0, punycode@^2.1.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
@@ -2244,6 +2435,11 @@ pure-rand@^6.0.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-6.1.0.tgz#d173cf23258231976ccbdb05247c9787957604f2"
   integrity sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==
+
+qs@~6.5.2:
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
+  integrity sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -2254,6 +2450,32 @@ react-is@^18.0.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+
+request@^2.87.0:
+  version "2.88.2"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
+  integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.8.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.6"
+    extend "~3.0.2"
+    forever-agent "~0.6.1"
+    form-data "~2.3.2"
+    har-validator "~5.1.3"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.19"
+    oauth-sign "~0.9.0"
+    performance-now "^2.1.0"
+    qs "~6.5.2"
+    safe-buffer "^5.1.2"
+    tough-cookie "~2.5.0"
+    tunnel-agent "^0.6.0"
+    uuid "^3.3.2"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -2309,6 +2531,16 @@ run-parallel@^1.1.9:
   integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
     queue-microtask "^1.2.2"
+
+safe-buffer@^5.0.1, safe-buffer@^5.1.2:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
 semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"
@@ -2366,6 +2598,21 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
+
+sshpk@^1.7.0:
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.18.0.tgz#1663e55cddf4d688b86a46b77f0d5fe363aba028"
+  integrity sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==
+  dependencies:
+    asn1 "~0.2.3"
+    assert-plus "^1.0.0"
+    bcrypt-pbkdf "^1.0.0"
+    dashdash "^1.12.0"
+    ecc-jsbn "~0.1.1"
+    getpass "^0.1.1"
+    jsbn "~0.1.0"
+    safer-buffer "^2.0.2"
+    tweetnacl "~0.14.0"
 
 stack-utils@^2.0.3:
   version "2.0.6"
@@ -2470,6 +2717,26 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+tough-cookie@~2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
+  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
+  dependencies:
+    psl "^1.1.28"
+    punycode "^2.1.1"
+
+tunnel-agent@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
+  integrity sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==
+  dependencies:
+    safe-buffer "^5.0.1"
+
+tweetnacl@^0.14.3, tweetnacl@~0.14.0:
+  version "0.14.5"
+  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
+  integrity sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==
+
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
@@ -2512,6 +2779,11 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+uuid@^3.3.2:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
+  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
 v8-to-istanbul@^9.0.1:
   version "9.2.0"
   resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz#2ed7644a245cddd83d4e087b9b33b3e62dfd10ad"
@@ -2520,6 +2792,15 @@ v8-to-istanbul@^9.0.1:
     "@jridgewell/trace-mapping" "^0.3.12"
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^2.0.0"
+
+verror@1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
+  integrity sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==
+  dependencies:
+    assert-plus "^1.0.0"
+    core-util-is "1.0.2"
+    extsprintf "^1.2.0"
 
 walker@^1.0.8:
   version "1.0.8"


### PR DESCRIPTION
### Fixes track selection for videos with strange resolutions
Fixes track selection so instead of looking at the exact resolution values (720, 1080, 2160), it's looking at categories (<= 720, between 720-1080, and between 1080-2160). 

This is to cater for videos with strange resolutions, like youtube shorts and other weird things. 

### Change audio track selection
This is technically a non-backwards compatible change to V4, since https+mp4a tracks are now returned (previously filtered out). 

However, v3.8.0 of the box release still used processV3. I'll put in a PR to change the code for the upcoming v3.8.3 release. 

### Testing script and testing video list
https://vivi-internal.atlassian.net/wiki/spaces/EN/pages/680853626/Video+Direct+test+collection <-- First table now has a list of 8 videos that I think should be tested every time we change the track selection code. 

Added a test script. Still needs a human to eyeball the output of the test script for each of those 8 videos. (Once things settle down with ytdl, we should try and make unit tests work again. Right now the available youtube tracks seem to be changing so often I don't think it's worth fixing tests. Whoever changes the track selection code is going to have to check those 8 videos and eyeball all the results). 
![image](https://github.com/user-attachments/assets/f1383589-2291-4c8e-90c0-09b48703996b)



--------

### Checklist

Before merge:
- [ ] modifications to process, processV2 and processV3 MUST be backwards compatible

After merge checklist:
- [ ] update commit hash of ytdl-process in vivi-box\app\package.json
- [ ] update commit hash of ytdl-process in vivi-service-ytdl\package.json
