### PR TITLE
VIVI-13452 Add blank type declaration file

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,5 +13,6 @@
     "lint:fix": "eslint . --fix",
     "test": "jest",
     "test-track-selection": "node tests/track_selection_test_script"
-  }
+  },
+  "types": "./ytdl-process.d.ts"
 }

--- a/ytdl-process.d.ts
+++ b/ytdl-process.d.ts
@@ -1,0 +1,2 @@
+// ytdl-process.d.ts
+declare module 'ytdl-process';


### PR DESCRIPTION
### Description

Add a blank type declaration file, to appease TS

https://github.com/viviedu/vivi-service-ytdl/pull/141 adds this library back in, but in the time where the library wasn't there, vivi-service-ytdl was re-written in TS. This is to appease TS for the imports of this library

--------

### Checklist

Before merge:
- [x] modifications to process, processV2 and processV3 MUST be backwards compatible

After merge checklist:
- [ ] update commit hash of ytdl-process in vivi-box\app\package.json
- [ ] update commit hash of ytdl-process in vivi-service-ytdl\package.json
