### PR TITLE
VIVI-14171 Unify locale data in ytdl-process response

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,13 +107,12 @@ module.exports.process = (output, origin) => {
 
   const cookies = data.http_headers && data.http_headers.Cookie || '';
   const duration = data.duration || 0;
-  const subtitlesForAllLocales = getSubtitlesForAllLocales(origin, subtitles, automatic_captions);
+  const subtitlesForAllLocales = getSubtitlesForAllLocales(origin, subtitles, automatic_captions, true);
   const title = data.title || '';
   const thumbnail = data.thumbnail || '';
-  
+
   if (url) {
     return {
-      // subtitle_url: subtitleUrl,
       cookies,
       duration,
       subtitles: subtitlesForAllLocales,
@@ -138,12 +137,11 @@ module.exports.processV2 = (output, origin) => {
 
   const cookies = data.http_headers && data.http_headers.Cookie || '';
   const duration = data.duration || 0;
-  const subtitlesForAllLocales = getSubtitlesForAllLocales(origin, subtitles, automatic_captions);
+  const subtitlesForAllLocales = getSubtitlesForAllLocales(origin, subtitles, automatic_captions, true);
   const title = data.title || '';
 
   if (data.fragments) {
     return {
-      // subtitle_url: subtitleUrl,
       cookies,
       duration,
       manifest: generateManifest(data),
@@ -155,7 +153,6 @@ module.exports.processV2 = (output, origin) => {
 
   if (url) {
     return {
-      // subtitle_url: subtitleUrl,
       cookies,
       duration,
       subtitles: subtitlesForAllLocales,
@@ -214,7 +211,6 @@ module.exports.processV3 = (output, origin, locales = []) => {
   }
 
   return {
-    // subtitle_url: subtitleUrl,
     audio: audio_track,
     cookies,
     duration,
@@ -269,9 +265,8 @@ module.exports.processV4 = (output, origin, locales = []) => {
       return { type: 'url', acodec, url: audio_url, format_id: audio_format, protocol: audio_protocol, language: audio_language };
     }
   }).filter(Boolean);
-  
+
   return {
-    // subtitle_url: subtitleUrl,
     audio: formattedTracks,
     cookies,
     duration,
@@ -514,11 +509,12 @@ function audioTrackSort(a, b) {
   return a.format_id < b.format_id ? -1 : 1;
 }
 
-function getSubtitlesForAllLocales(origin, subtitles, automatic_captions) {
+function getSubtitlesForAllLocales(origin, subtitles, automatic_captions, useEmptyLocale = false) {
   const subtitlesForAllLocales = {};
-  var subtitleFile, subtitleUrl;
+  var subtitleFile, subtitleUrl, subtitleLocale;
   for (const locale of LOCALES) {
-    subtitleFile = findBestSubtitleFile(subtitles, locale) || findBestSubtitleFile(automatic_captions, locale);
+    subtitleLocale = useEmptyLocale ? [] : locale;
+    subtitleFile = findBestSubtitleFile(subtitles, subtitleLocale) || findBestSubtitleFile(automatic_captions, subtitleLocale);
     subtitleUrl = subtitleFile ? `${origin}/ytdl/vtt?suburi=${encodeURIComponent(subtitleFile.subs.url)}` : '';
     subtitlesForAllLocales[locale[0]] = subtitleUrl;
   }

--- a/index.js
+++ b/index.js
@@ -107,7 +107,8 @@ module.exports.process = (output, origin) => {
 
   const cookies = data.http_headers && data.http_headers.Cookie || '';
   const duration = data.duration || 0;
-  const subtitlesForAllLocales = getSubtitlesForAllLocales(origin, subtitles, automatic_captions, true);
+  const subtitleFile = findBestSubtitleFile(subtitles) || findBestSubtitleFile(automatic_captions);
+  const subtitleUrl = subtitleFile ? `${origin}/ytdl/vtt?suburi=${encodeURIComponent(subtitleFile.subs.url)}` : '';
   const title = data.title || '';
   const thumbnail = data.thumbnail || '';
 
@@ -115,7 +116,7 @@ module.exports.process = (output, origin) => {
     return {
       cookies,
       duration,
-      subtitles: subtitlesForAllLocales,
+      subtitle_url: subtitleUrl,
       thumbnail,
       title,
       url
@@ -137,7 +138,8 @@ module.exports.processV2 = (output, origin) => {
 
   const cookies = data.http_headers && data.http_headers.Cookie || '';
   const duration = data.duration || 0;
-  const subtitlesForAllLocales = getSubtitlesForAllLocales(origin, subtitles, automatic_captions, true);
+  const subtitleFile = findBestSubtitleFile(subtitles) || findBestSubtitleFile(automatic_captions);
+  const subtitleUrl = subtitleFile ? `${origin}/ytdl/vtt?suburi=${encodeURIComponent(subtitleFile.subs.url)}` : '';
   const title = data.title || '';
 
   if (data.fragments) {
@@ -145,7 +147,7 @@ module.exports.processV2 = (output, origin) => {
       cookies,
       duration,
       manifest: generateManifest(data),
-      subtitles: subtitlesForAllLocales,
+      subtitle_url: subtitleUrl,
       title,
       type: 'manifest'
     };

--- a/index.js
+++ b/index.js
@@ -511,11 +511,10 @@ function audioTrackSort(a, b) {
 
 function getSubtitlesForAllLocales(origin, subtitles, automatic_captions, useEmptyLocale = false) {
   const subtitlesForAllLocales = {};
-  var subtitleFile, subtitleUrl, subtitleLocale;
   for (const locale of LOCALES) {
-    subtitleLocale = useEmptyLocale ? [] : locale;
-    subtitleFile = findBestSubtitleFile(subtitles, subtitleLocale) || findBestSubtitleFile(automatic_captions, subtitleLocale);
-    subtitleUrl = subtitleFile ? `${origin}/ytdl/vtt?suburi=${encodeURIComponent(subtitleFile.subs.url)}` : '';
+    const subtitleLocale = useEmptyLocale ? [] : locale;
+    const subtitleFile = findBestSubtitleFile(subtitles, subtitleLocale) || findBestSubtitleFile(automatic_captions, subtitleLocale);
+    const subtitleUrl = subtitleFile ? `${origin}/ytdl/vtt?suburi=${encodeURIComponent(subtitleFile.subs.url)}` : '';
     subtitlesForAllLocales[locale[0]] = subtitleUrl;
   }
   return subtitlesForAllLocales;

--- a/index.js
+++ b/index.js
@@ -157,7 +157,7 @@ module.exports.processV2 = (output, origin) => {
     return {
       cookies,
       duration,
-      subtitles: subtitlesForAllLocales,
+      subtitle_url: subtitleUrl,
       title,
       type: 'url',
       url


### PR DESCRIPTION
### Description

We want to remove “locale“ from the cache key. To do this, when we cache an entry, we will cache a map of subtitle urls mapped to each of the locales, and then based on the locale that has been sent in the request, we will extract the subtitle url from this map.

In this way, if the urls are the same, we will hit the cache, and it doesn't matter what locale is in the request.

This field `subtitles` will look like this:

![image](https://github.com/user-attachments/assets/ddd7081a-d844-4d32-afcf-bc04b52b4355)

--------

### Checklist

Before merge:
- [ ] modifications to process, processV2 and processV3 MUST be backwards compatible

After merge checklist:
- [ ] update commit hash of ytdl-process in vivi-box\app\package.json
- [ ] update commit hash of ytdl-process in vivi-service-ytdl\package.json
