### PR TITLE
VIVI-14218 Remove optional chaining which is unsupported by Node 12

### DIFF
--- a/index.js
+++ b/index.js
@@ -362,10 +362,10 @@ function processVideoFormats(formats, isStream) {
 function videoTrackSort(a, b) {
   // Prefer English audio
   const englishAudioTag = 'original:lang%3Den';
-  if (a.url?.includes(englishAudioTag) && !b.url?.includes(englishAudioTag)) {
+  if (a.url ? a.url.includes(englishAudioTag) : null && b.url ? !b.url.includes(englishAudioTag) : null) {
     return -1;
   }
-  if (!a.url?.includes(englishAudioTag) && b.url?.includes(englishAudioTag)) {
+  if (a.url ? !a.url.includes(englishAudioTag) : null && b.url ? b.url.includes(englishAudioTag) : null) {
     return 1;
   }
 

--- a/index.js
+++ b/index.js
@@ -362,10 +362,10 @@ function processVideoFormats(formats, isStream) {
 function videoTrackSort(a, b) {
   // Prefer English audio
   const englishAudioTag = 'original:lang%3Den';
-  if (a.url ? a.url.includes(englishAudioTag) : null && b.url ? !b.url.includes(englishAudioTag) : null) {
+  if ((a.url && a.url.includes(englishAudioTag)) && !(b.url && b.url.includes(englishAudioTag))) {
     return -1;
   }
-  if (a.url ? !a.url.includes(englishAudioTag) : null && b.url ? b.url.includes(englishAudioTag) : null) {
+  if (!(a.url && a.url.includes(englishAudioTag)) && (b.url && b.url.includes(englishAudioTag))) {
     return 1;
   }
 


### PR DESCRIPTION
### Description

Unfortunately, optional chaining is not supported by Node 12 without transpilation.

--------

### Checklist

Before merge:
- [x] modifications to process, processV2 and processV3 MUST be backwards compatible

After merge checklist:
- [ ] update commit hash of ytdl-process in vivi-box\app\package.json
- [ ] update commit hash of ytdl-process in vivi-service-ytdl\package.json
