### PR TITLE
VIVI-17841 Fix js runtime arg

### DIFF
--- a/service.py
+++ b/service.py
@@ -46,7 +46,7 @@ class Handler(BaseHTTPRequestHandler):
 
         ydl_opts = {
             'forcejson': True,
-            'js_runtimes': ['node'],
+            'js_runtimes': { 'node': { 'config': {} } },
             'logger': self,
             'quiet': True,
             'simulate': True


### PR DESCRIPTION
### Description

The version of yt-dlp has been merged and a dev/nightly build was released. After testing with this version of `yt-dlp` the js runtime arg needs to be updated.

--------

### Checklist

Before merge:
- [x] modifications to process, processV2 and processV3 MUST be backwards compatible

After merge checklist:
- [ ] update commit hash of ytdl-process in vivi-box\app\package.json
- [ ] update commit hash of ytdl-process in vivi-service-ytdl\package.json
