### PR TITLE
VIVI-17841 Fix fix JS runtime arg

### DIFF
--- a/service.py
+++ b/service.py
@@ -46,7 +46,7 @@ class Handler(BaseHTTPRequestHandler):
 
         ydl_opts = {
             'forcejson': True,
-            'js_runtimes': { 'node': { 'config': {} } },
+            'js_runtimes': { 'node': {} },
             'logger': self,
             'quiet': True,
             'simulate': True


### PR DESCRIPTION
### Description

The arg in this PR which I had originally was correct in the end :brainlet:. Although the current one works the new one is correct based on the `yt-dlp` code and documentation. 

--------

### Checklist

Before merge:
- [x] modifications to process, processV2 and processV3 MUST be backwards compatible

After merge checklist:
- [ ] update commit hash of ytdl-process in vivi-box\app\package.json
- [ ] update commit hash of ytdl-process in vivi-service-ytdl\package.json
