### PR TITLE
VIVI-19522 Remove nsfw extractors from ytdl

### DIFF
--- a/generate_filtered_extractors.py
+++ b/generate_filtered_extractors.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+import argparse
+from yt_dlp.extractor import gen_extractor_classes
+
+# list of strings to reject any extractors which have these values as a substring
+# derived from yt-dlp extractors list
+FORBIDDEN_EXTRACTOR_STRINGS = (
+  'sex',
+  'porn',
+  'xx',
+  'redtube',
+  'cam',
+  '4tube',
+  'load',
+  'gasm',
+  'bang',
+  'iwara',
+  'jizz',
+  'mother',
+  'kink',
+  'fap',
+  'strip',
+  'toypics',
+  'thisvid',
+  'chaturbate',
+  'rule34',
+  'tube8',
+  'erocast',
+  'eroprofile',
+  'manyvids',
+  'tube8',
+  'fc2',
+  'scrolller',
+  'beeg',
+  'peekvids',
+  'playvids',
+  'drtuber',
+  'oftv',
+  'nuvid',
+  'noodlemagazine',
+  'xvideos',
+  'xhamster',
+  'tnaflix',
+  'empflix',
+  'redgifs',
+  'xstream',
+  'pr0gramm',
+  'myvidster',
+  'murrtube',
+  'goshgay'
+)
+
+def generate_filtered_extractors():
+    extractors = [extractor.IE_NAME.lower() for extractor in gen_extractor_classes()]
+
+    # start list with the default extractors and then add the ones we want to remove by prefixing extractor name with '-'
+    return ['default'] + [
+        f'-{extractor}' for extractor in extractors
+        if any(forbidden_extractor_str in extractor.lower() for forbidden_extractor_str in FORBIDDEN_EXTRACTOR_STRINGS)
+    ]
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-file", required=True, type=str)
+
+    extractor_list = generate_filtered_extractors()
+    
+    output_file = parser.parse_args().output_file
+    if output_file:
+        with open(output_file, 'w', encoding='utf-8') as f:
+            f.write(str(extractor_list))

--- a/service.py
+++ b/service.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+from generate_filtered_extractors import generate_filtered_extractors
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from socketserver import ThreadingMixIn
 from sys import stderr
@@ -45,6 +46,7 @@ class Handler(BaseHTTPRequestHandler):
         version = qs.get('version', "2")
 
         ydl_opts = {
+            'allowed_extractors': generate_filtered_extractors(),
             'forcejson': True,
             'js_runtimes': { 'node': {} },
             'logger': self,


### PR DESCRIPTION
### Description

this filters the extractors of ytdl to prevent nsfw sites from working in play content/ signage 

--------

### Checklist

Before merge:
- [x] modifications to process, processV2 and processV3 MUST be backwards compatible

After merge checklist:
- [ ] update commit hash of ytdl-process in vivi-box\app\package.json
- [ ] update commit hash of ytdl-process in vivi-service-ytdl\package.json
