### PR TITLE
VIVI-19808 VIVI-19842 Download video to tmp

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -7,8 +7,18 @@ node = "24"
 
 [settings]
 python.uv_venv_auto = true
+experimental = true
+
+[hooks]
+postinstall = "mise run activate"
+
+[tasks.activate]
+description = "activates the config"
+alias = "a"
+run = "corepack enable"
 
 [tasks.install-frozen]
+depends = ["activate"]
 description = "Install dependencies"
 alias = "if"
 run = "yarn install --frozen-lockfile && uv sync --frozen"
@@ -27,3 +37,4 @@ run = "ruff check && ty check && yarn lint"
 description = "Lint the code"
 alias = "lf"
 run = "ruff format && yarn lint:fix"
+


### PR DESCRIPTION
### Description

To enable the gcp and proxy ytdl services to download videos and upload them to s3 I added an extra path to `service.py` to that replicates the download functions from [vivi-lambda-video-downloader](https://github.com/viviedu/vivi-lambda-video-downloader). 

I also added some python linting and config but those commits can be dropped if we don't want them. 

--------

### Checklist

Before merge:
- [x] modifications to process, processV2 and processV3 MUST be backwards compatible

After merge checklist:
- [ ] update commit hash of ytdl-process in vivi-box\app\package.json
- [ ] update commit hash of ytdl-process in vivi-service-ytdl\package.json
