### PR TITLE
VIVI-23090 Add no playlist option

### DIFF
--- a/service.py
+++ b/service.py
@@ -161,6 +161,7 @@ class Handler(BaseHTTPRequestHandler):
                 ydl_opts["proxy"] = proxy_url[0]
 
             filename = tempfile.mkdtemp()
+            ydl_opts["noplaylist"] = True
             ydl_opts["cachedir"] = False
             ydl_opts["simulate"] = False
             ydl_opts["outtmpl"] = f"{filename}/%(id)s_%(format_id)s.%(ext)s"


### PR DESCRIPTION
### Description

When someone adds a youtube vid with a playlist we should only download the current vid.

--------

### Checklist

Before merge:
- [x] modifications to process, processV2 and processV3 MUST be backwards compatible

After merge checklist:
- [ ] update commit hash of ytdl-process in vivi-box\app\package.json
- [ ] update commit hash of ytdl-process in vivi-service-ytdl\package.json
