### PR TITLE
VIVI-23212 Retry downloads more

### DIFF
--- a/service.py
+++ b/service.py
@@ -14,29 +14,32 @@ MAX_DOWNLOAD_BIT_RATE_KB = "8000"  # 8Mbps same as in the media lambda
 
 
 class Handler(BaseHTTPRequestHandler):
-    def debug(self, msg):
-        print("ydl debug: {}".format(msg), file=stderr)
+    def debug(self, msg: str, level="debug"):
+        print(json.dumps({"message": msg, "level": level}), file=stderr)
 
     def warning(self, msg):
-        print("ydl warning: {}".format(msg), file=stderr)
-
-        # 429 responses that come through as warnings fail to
-        # be caught by the ytdl service, so we must escalate them
-        # to errors
-        if "429" in msg or "Too Many Request" in msg:
-            self.fail(msg)
-        pass
+        self.debug(msg, "warning")
 
     def error(self, msg):
-        print("ydl error: {}".format(msg), file=stderr)
-        pass
+        self.debug(msg, "error")
 
-    def fail(self, msg):
+    def fail(self, msg: object):
         print(msg, file=stderr)
         # create our own error response rather than using send_error to
         # avoid bloating response with HTML wrapping
-        response_bytes = msg.encode()
+        response_bytes = json.dumps(msg).encode()
         self.send_response(500)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", str(len(response_bytes)))
+        self.end_headers()
+        self.wfile.write(response_bytes)
+
+    def success(self, msg: object):
+        print(msg, file=stderr)
+        # create our own error response rather than using send_error to
+        # avoid bloating response with HTML wrapping
+        response_bytes = json.dumps(msg).encode()
+        self.send_response(200)
         self.send_header("Content-Type", "text/plain")
         self.send_header("Content-Length", str(len(response_bytes)))
         self.end_headers()
@@ -47,15 +50,9 @@ class Handler(BaseHTTPRequestHandler):
             with YoutubeDL(ytdl_opts) as ydl:
                 info = ydl.extract_info(url, download=False)
 
-            response = json.dumps(ydl.sanitize_info(info))
-            response_bytes = response.encode()
-            self.send_response(200)
-            self.send_header("Content-Type", "text/plain")
-            self.send_header("Content-Length", str(len(response_bytes)))
-            self.end_headers()
-            self.wfile.write(response_bytes)
+            self.success(ydl.sanitize_info(info))
         except Exception as ex:
-            self.fail("ydl exception: {}".format(repr(ex)))
+            self.fail(ex)
             return
 
     def download_split_tracks(self, ytdl_opts, url, filename):
@@ -93,7 +90,7 @@ class Handler(BaseHTTPRequestHandler):
             return False
 
     def download_combined_track(self, ytdl_opts, url, filename):
-        ytdl_opts["format"] = f"best[acodec!=none][vcodec!=none][tbr=<{MAX_DOWNLOAD_BIT_RATE_KB}]"
+        ytdl_opts["format"] = f"best[acodec!=none][vcodec!=none][tbr<={MAX_DOWNLOAD_BIT_RATE_KB}]"
 
         try:
             with YoutubeDL(ytdl_opts) as ydl:
@@ -167,7 +164,7 @@ class Handler(BaseHTTPRequestHandler):
             ydl_opts["outtmpl"] = f"{filename}/%(id)s_%(format_id)s.%(ext)s"
             ydl_opts["sleep_requests"] = 2  # 2s between HTTP requests
             ydl_opts["socket_timeout"] = 120
-            ydl_opts["retries"] = 5
+            ydl_opts["retries"] = float("inf")  # I know this looks like a lot but we have the fragment tries limit below that we want to use
             ydl_opts["fragment_retries"] = 5
 
             download_res = self.download_combined_track(ydl_opts, qs["url"][0], filename)
@@ -175,17 +172,11 @@ class Handler(BaseHTTPRequestHandler):
                 download_res = self.download_split_tracks(ydl_opts, qs["url"][0], filename)
 
             if download_res:
-                response = json.dumps(download_res)
-                response_bytes = response.encode()
-                self.send_response(200)
-                self.send_header("Content-Type", "text/plain")
-                self.send_header("Content-Length", str(len(response_bytes)))
-                self.end_headers()
-                self.wfile.write(response_bytes)
+                self.success(download_res)
             else:
-                self.fail("failed all downloads")
+                self.fail({"message": "failed all downloads"})
         else:
-            self.fail("no matching path: {}".format(url.path))
+            self.fail({"message": "no matching path", "url": url.path})
 
 
 class ThreadingHTTPServer(ThreadingMixIn, HTTPServer):

--- a/service.py
+++ b/service.py
@@ -17,29 +17,15 @@ class Handler(BaseHTTPRequestHandler):
     def debug(self, msg: str, level="debug"):
         print(json.dumps({"message": msg, "level": level}), file=stderr)
 
-    def warning(self, msg):
+    def warning(self, msg: str):
         self.debug(msg, "warning")
 
-    def error(self, msg):
+    def error(self, msg: str):
         self.debug(msg, "error")
 
-    def fail(self, msg: object):
-        print(msg, file=stderr)
-        # create our own error response rather than using send_error to
-        # avoid bloating response with HTML wrapping
+    def respond(self, status: int, msg: object):
         response_bytes = json.dumps(msg).encode()
-        self.send_response(500)
-        self.send_header("Content-Type", "text/plain")
-        self.send_header("Content-Length", str(len(response_bytes)))
-        self.end_headers()
-        self.wfile.write(response_bytes)
-
-    def success(self, msg: object):
-        print(msg, file=stderr)
-        # create our own error response rather than using send_error to
-        # avoid bloating response with HTML wrapping
-        response_bytes = json.dumps(msg).encode()
-        self.send_response(200)
+        self.send_response(status)
         self.send_header("Content-Type", "text/plain")
         self.send_header("Content-Length", str(len(response_bytes)))
         self.end_headers()
@@ -50,12 +36,12 @@ class Handler(BaseHTTPRequestHandler):
             with YoutubeDL(ytdl_opts) as ydl:
                 info = ydl.extract_info(url, download=False)
 
-            self.success(ydl.sanitize_info(info))
+            self.respond(200, ydl.sanitize_info(info))
         except Exception as ex:
-            self.fail(ex)
+            self.respond(500, ex)
             return
 
-    def download_split_tracks(self, ytdl_opts, url, filename):
+    def download_split_tracks(self, ytdl_opts: dict, url: str, filename: str):
         ytdl_opts["format"] = f"bestvideo[vbr<={MAX_DOWNLOAD_BIT_RATE_KB}],bestaudio"
 
         try:
@@ -89,7 +75,7 @@ class Handler(BaseHTTPRequestHandler):
             self.warning(f"error: {str(e)}, url={url}")
             return False
 
-    def download_combined_track(self, ytdl_opts, url, filename):
+    def download_combined_track(self, ytdl_opts: dict, url: str, filename: str):
         ytdl_opts["format"] = f"best[acodec!=none][vcodec!=none][tbr<={MAX_DOWNLOAD_BIT_RATE_KB}]"
 
         try:
@@ -172,11 +158,11 @@ class Handler(BaseHTTPRequestHandler):
                 download_res = self.download_split_tracks(ydl_opts, qs["url"][0], filename)
 
             if download_res:
-                self.success(download_res)
+                self.respond(200, download_res)
             else:
-                self.fail({"message": "failed all downloads"})
+                self.respond(500, {"message": "failed all downloads"})
         else:
-            self.fail({"message": "no matching path", "url": url.path})
+            self.respond(500, {"message": "no matching path", "url": url.path})
 
 
 class ThreadingHTTPServer(ThreadingMixIn, HTTPServer):

--- a/service.py
+++ b/service.py
@@ -24,9 +24,11 @@ class Handler(BaseHTTPRequestHandler):
         self.debug(msg, "error")
 
     def respond(self, status: int, msg: object):
+        # create our own response rather than using send_success/send_error to
+        # avoid bloating response with HTML wrapping
         response_bytes = json.dumps(msg).encode()
         self.send_response(status)
-        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(response_bytes)))
         self.end_headers()
         self.wfile.write(response_bytes)


### PR DESCRIPTION
### Description

For long videos we want to limit retries on a fragment level not on the whole video level. When downloading a 10 hour long video it is not unexpected to drop a dozen of the 1000s of fragments and in that case we should retry.
I also cleaned up the logging and failure messages.

--------

### Checklist

Before merge:
- [x] modifications to process, processV2 and processV3 MUST be backwards compatible

After merge checklist:
- [ ] update commit hash of ytdl-process in vivi-box\app\package.json
- [ ] update commit hash of ytdl-process in vivi-service-ytdl\package.json
