### PR TITLE
BAU-738 categorize logging from ytdl exceptions

### DIFF
--- a/service.py
+++ b/service.py
@@ -40,7 +40,7 @@ class Handler(BaseHTTPRequestHandler):
 
             self.respond(200, ydl.sanitize_info(info))
         except Exception as ex:
-            self.respond(500, ex)
+            self.respond(500, {"message": "ydl exception: {}".format(repr(ex))})
             return
 
     def download_split_tracks(self, ytdl_opts: dict, url: str, filename: str):


### PR DESCRIPTION
### Description

In response to
https://github.com/viviedu/ytdl-process/pull/71/changes#diff-3a47b4c168e35e57a3d797e6f7df5b1d0d9bde03171df209c0210c1c34e3dd5dR43

We lose information on the specific errors from exceptions thrown from `ytdl_request`. 
```json
  {
    "error": {
      "name": "RequestError",
      "cause": { "code": "ECONNRESET" },
      "message": "Error: socket hang up",
      "options": { "uri": "http://127.0.0.1:4444/process?url=…rnXIjl_Rzy4…" }
    },
    "level": "error", "message": "error processing video", "url": "https://www.youtube.com/watch?v=rnXIjl_Rzy4"
  }
```

Sample logging from this PR change.
```json
  {
    "error": {
      "name": "StatusCodeError",
      "statusCode": 500,
      "error": "ydl exception: DownloadError('ERROR: [youtube] rnXIjl_Rzy4: This live stream recording is not available.')",
      "response": { "statusCode": 500, "headers": { "content-type": "text/plain" } }
    },
    "level": "error", "message": "error processing video", "url": "https://www.youtube.com/watch?v=rnXIjl_Rzy4"
  }
```


--------

### Checklist

Before merge:
- [x] modifications to process, processV2 and processV3 MUST be backwards compatible

After merge checklist:
- [ ] update commit hash of ytdl-process in vivi-box\app\package.json
- [ ] update commit hash of ytdl-process in vivi-service-ytdl\package.json
