### PR TITLE
VIVI-23818 Remove filtering https video tracks

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports.ARGUMENTS_MULTI_FORMAT = [
   '--write-sub',
   '--write-auto-sub',
   '--no-playlist',
-  '--extractor-args', 'youtube:player-client=ios,web_creator,web_safari',
+  '--extractor-args', 'youtube:player-client=android_vr,web_safari,tv',
   '-J'
 ];
 
@@ -426,15 +426,12 @@ function videoTrackSort(a, b) {
 }
 
 function filterVideoFormatCodecs(format) {
-  const { acodec, format_id, protocol, vcodec } = format;
+  const { format_id, vcodec } = format;
   return format_id !== 'source' && !format_id.startsWith('http')
     // ignore tracks with no video
     && vcodec && vcodec !== 'none'
     // boxes can't play vp9 or av01
-    && !vcodec.includes('av01') && !vcodec.includes('vp9') && !vcodec.includes('vp09')
-    // In our gstreamer pipeline, seeking breaks for video only tracks that have protocol=https
-    // I couldn't figure out why. Therefore we take tracks with protocol=m3u8 or protocol=dash
-    && (acodec !== 'none' || (acodec === 'none' && !protocol.includes('https')));
+    && !vcodec.includes('av01') && !vcodec.includes('vp9') && !vcodec.includes('vp09');
 }
 
 function filterVideoFormatFps(format) {

--- a/service.py
+++ b/service.py
@@ -158,10 +158,11 @@ class Handler(BaseHTTPRequestHandler):
             ydl_opts["writeautomaticsub"] = True
             ydl_opts["writesubtitles"] = True
 
-            # by default, yt-dlp queries each url twice, once as an ios client and once as a web client. Youtube returns different tracks to
-            # different clients. We add 'web_safari' to the list, because this causes youtube to return combined 720p/1080p m3u8 tracks which
-            # are handy to have. More clients = hitting youtube more times. This option is ignored by yt-dlp for URLs that are not youtube.
-            ydl_opts["extractor_args"] = {"youtube": {"player_client": ["ios", "web_creator", "web_safari"]}}
+            # web_creator now requires sign-in (fatal without cookies) and ios/web_safari only return
+            # SABR/PO-token-gated formats with no usable URL, so those clients yield nothing playable.
+            # android_vr is tokenless and still returns direct https URLs; web_safari/tv are kept as
+            # non-fatal extras (can still add HLS). This option is ignored by yt-dlp for non-youtube URLs.
+            ydl_opts["extractor_args"] = {"youtube": {"player_client": ["android_vr", "web_safari", "tv"]}}
             self.ytdl_request(ydl_opts, qs["url"][0])
         elif url.path == "/process_playlist":
             ydl_opts["extract_flat"] = True

--- a/tests/test.js
+++ b/tests/test.js
@@ -108,8 +108,11 @@ test('filterVideoFormatCodecs rejects tracks with bad codecs', () => {
   expect(Boolean(filterVideoFormatCodecs(bad3))).toBe(false);
 });
 
-test('filterVideoFormatCodecs rejects video-only https tracks', () => {
-  const bad1 = { format_id: '22', vcodec: 'avc1', acodec: 'none', protocol: 'https' };
+test('filterVideoFormatCodecs allows avc1 video-only https tracks and rejects vp9/av01', () => {
+  const good1 = { format_id: '137', vcodec: 'avc1.640028', acodec: 'none', protocol: 'https' };
+  expect(Boolean(filterVideoFormatCodecs(good1))).toBe(true);
+
+  const bad1 = { format_id: '248', vcodec: 'vp9', acodec: 'none', protocol: 'https' };
   expect(Boolean(filterVideoFormatCodecs(bad1))).toBe(false);
 });
 


### PR DESCRIPTION
### Description

Remove filtering for `https` tracks and update tests. There have been changes were we no longer are getting `m3u8` formats for YouTube videos and also the player clients we use have been updated as the previous ones require a token.

--------

### Checklist

Before merge:
- [ ] modifications to process, processV2 and processV3 MUST be backwards compatible

After merge checklist:
- [ ] update commit hash of ytdl-process in vivi-box\app\package.json
- [ ] update commit hash of ytdl-process in vivi-service-ytdl\package.json
